### PR TITLE
Use client-only dynamic TopBar

### DIFF
--- a/widgets/top-bar/ui/top-bar.client.tsx
+++ b/widgets/top-bar/ui/top-bar.client.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import React from 'react';
+import { Category } from '@prisma/client';
+import { cn } from '@shared/lib/utils';
+import { Container } from '@shared/ui';
+import { Categories } from '@widgets/filters-bar/ui/categories';
+
+export interface TopBarProps {
+  className?: string;
+  categories: Category[];
+}
+
+export const TopBarClient: React.FC<TopBarProps> = ({
+  className,
+  categories,
+}) => {
+  return (
+    <div
+      className={cn(
+        'sticky top-0 bg-white py-5 shadow-lg shadow-black/5 z-10',
+        className
+      )}
+    >
+      <Container className={'flex flex-wrap items-center justify-between'}>
+        <Categories items={categories} />
+        {/*<SortPopup />*/}
+      </Container>
+    </div>
+  );
+};

--- a/widgets/top-bar/ui/top-bar.tsx
+++ b/widgets/top-bar/ui/top-bar.tsx
@@ -1,27 +1,9 @@
-'use client';
-import React from 'react';
-import { cn } from '@shared/lib/utils';
-import { Categories } from '@widgets/filters-bar/ui/categories';
-import { Container } from '@shared/ui';
-import { Category } from '@prisma/client';
+import dynamic from 'next/dynamic';
+import type { TopBarProps } from './top-bar.client';
 
-interface Props {
-  className?: string;
-  categories: Category[];
-}
+export const TopBar = dynamic<TopBarProps>(
+  () => import('./top-bar.client').then((mod) => mod.TopBarClient),
+  { ssr: false }
+);
 
-export const TopBar: React.FC<Props> = ({ className, categories }) => {
-  return (
-    <div
-      className={cn(
-        'sticky top-0 bg-white py-5 shadow-lg shadow-black/5 z-10',
-        className
-      )}
-    >
-      <Container className={'flex flex-wrap items-center justify-between'}>
-        <Categories items={categories} />
-        {/*<SortPopup />*/}
-      </Container>
-    </div>
-  );
-};
+export type { TopBarProps };


### PR DESCRIPTION
## Summary
- wrap the TopBar export in a dynamic import with ssr disabled to prevent server rendering store usage
- move the TopBar UI into a client component for safe use of useCategoryStore-dependent children

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69302522f96483249e7d36c93c932f4b)